### PR TITLE
Fix GLib open warning

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -7,7 +7,6 @@ use crate::note::{NOTES_DIR};
 pub fn run_gui() {
     let app = Application::builder()
         .application_id("com.example.notes")
-        .flags(gio::ApplicationFlags::HANDLES_OPEN)
         .build();
 
     app.connect_activate(|app| {
@@ -73,5 +72,9 @@ pub fn run_gui() {
         window.show();
     });
 
-    app.run();
+    // Pass an empty argument list to avoid `g_application_open` from
+    // interpreting leftover command line arguments as files to open.
+    // This prevents warnings about missing file handlers when running
+    // `cargo run gui` from the CLI.
+    app.run_with_args::<&str>(&[]);
 }


### PR DESCRIPTION
## Summary
- avoid `g_application_open` argument parsing by calling `run_with_args`

## Testing
- `cargo build`
- `cargo run gui` *(fails to open display)*

------
https://chatgpt.com/codex/tasks/task_b_685c0e1ca5108330b7c2dcb57fe929ae