### PR TITLE
Add graph view to notes GUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
 name = "notes"
 version = "0.1.0"
 dependencies = [
+ "cairo-rs",
  "gtk4",
  "vte4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 gtk4 = "0.9"
 vte4 = "0.8"
+cairo-rs = "0.20"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,68 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::note::NOTES_DIR;
+
+#[derive(Debug)]
+pub struct Graph {
+    pub nodes: Vec<Node>,
+    pub edges: Vec<(usize, usize)>,
+}
+
+#[derive(Debug)]
+pub struct Node {
+    pub name: String,
+    pub path: PathBuf,
+}
+
+fn canonicalize(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_alphanumeric())
+        .flat_map(|c| c.to_lowercase())
+        .collect::<String>()
+}
+
+pub fn build_graph() -> Graph {
+    let mut nodes = Vec::new();
+    let mut index_map: HashMap<String, usize> = HashMap::new();
+
+    if let Ok(entries) = fs::read_dir(NOTES_DIR) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                let canonical = canonicalize(stem);
+                if !index_map.contains_key(&canonical) {
+                    let name = path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let idx = nodes.len();
+                    nodes.push(Node { name, path: path.clone() });
+                    index_map.insert(canonical, idx);
+                }
+            }
+        }
+    }
+
+    let mut edges: HashSet<(usize, usize)> = HashSet::new();
+
+    for (canon, &i) in &index_map {
+        let path = &nodes[i].path;
+        if let Ok(content) = fs::read_to_string(path) {
+            let text = canonicalize(&content);
+            for (other_canon, &j) in &index_map {
+                if canon == other_canon {
+                    continue;
+                }
+                if text.contains(other_canon) {
+                    let (a, b) = if i < j { (i, j) } else { (j, i) };
+                    edges.insert((a, b));
+                }
+            }
+        }
+    }
+
+    Graph { nodes, edges: edges.into_iter().collect() }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,6 +7,7 @@ use crate::note::NOTES_DIR;
 #[derive(Debug)]
 pub struct Graph {
     pub nodes: Vec<Node>,
+    /// Directed edges using node indices (from -> to)
     pub edges: Vec<(usize, usize)>,
 }
 
@@ -39,13 +40,17 @@ pub fn build_graph() -> Graph {
                         .unwrap_or_default()
                         .to_string();
                     let idx = nodes.len();
-                    nodes.push(Node { name, path: path.clone() });
+                    nodes.push(Node {
+                        name,
+                        path: path.clone(),
+                    });
                     index_map.insert(canonical, idx);
                 }
             }
         }
     }
 
+    // store directed edges using indices
     let mut edges: HashSet<(usize, usize)> = HashSet::new();
 
     for (canon, &i) in &index_map {
@@ -57,12 +62,14 @@ pub fn build_graph() -> Graph {
                     continue;
                 }
                 if text.contains(other_canon) {
-                    let (a, b) = if i < j { (i, j) } else { (j, i) };
-                    edges.insert((a, b));
+                    edges.insert((i, j));
                 }
             }
         }
     }
 
-    Graph { nodes, edges: edges.into_iter().collect() }
+    Graph {
+        nodes,
+        edges: edges.into_iter().collect(),
+    }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -136,6 +136,10 @@ fn open_graph_window(app: &Application) {
 
     let area = DrawingArea::new();
     area.set_draw_func(move |_, ctx, width, height| {
+        // clear the drawing area first
+        ctx.set_source_rgb(1.0, 1.0, 1.0);
+        ctx.paint().unwrap();
+
         let n = graph.nodes.len();
         if n == 0 {
             return;
@@ -189,6 +193,7 @@ fn open_graph_window(app: &Application) {
 
             ctx.move_to(x + 12.0, y + 4.0);
             let _ = ctx.show_text(&node.name);
+            ctx.new_path();
         }
     });
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,7 +1,7 @@
 use gtk4::prelude::*;
 use gtk4::{
-    Application, ApplicationWindow, Box, Button, DrawingArea, Label, ListBox, ListBoxRow,
-    Notebook, Orientation, ScrolledWindow, gio, glib,
+    Application, ApplicationWindow, Box, Button, DrawingArea, Label, ListBox, ListBoxRow, Notebook,
+    Orientation, ScrolledWindow, gio, glib,
 };
 use vte4::{PtyFlags, Terminal, TerminalExtManual};
 
@@ -154,12 +154,29 @@ fn open_graph_window(app: &Application) {
         }
 
         ctx.set_source_rgb(0.6, 0.6, 0.6);
-        for &(a, b) in &graph.edges {
-            let (sx, sy) = positions[a];
-            let (tx, ty) = positions[b];
+        ctx.set_line_width(1.0);
+        for &(from, to) in &graph.edges {
+            let (sx, sy) = positions[from];
+            let (tx, ty) = positions[to];
             ctx.move_to(sx, sy);
             ctx.line_to(tx, ty);
             let _ = ctx.stroke();
+
+            // draw arrow head
+            let angle = (ty - sy).atan2(tx - sx);
+            let arrow_len = 10.0;
+            let arrow_ang = std::f64::consts::PI / 8.0; // 22.5 deg
+            let lx = tx - arrow_len * (angle - arrow_ang).cos();
+            let ly = ty - arrow_len * (angle - arrow_ang).sin();
+            let rx = tx - arrow_len * (angle + arrow_ang).cos();
+            let ry = ty - arrow_len * (angle + arrow_ang).sin();
+
+            ctx.move_to(lx, ly);
+            ctx.line_to(tx, ty);
+            ctx.line_to(rx, ry);
+            ctx.close_path();
+            let _ = ctx.fill();
+            ctx.new_path();
         }
 
         for (i, node) in graph.nodes.iter().enumerate() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 // Declare note as a module
 mod note;
 mod gui;
+mod graph;
 use note::Note;
 
 fn main() {


### PR DESCRIPTION
## Summary
- visualize note relationships with a graph window
- compute note links by matching note names in text
- open graph view from the GUI

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_685c137c509c83309e2097cdb161bcbb