### PR TITLE
Add selectable vault path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,9 @@ dependencies = [
 [[package]]
 name = "notes-core"
 version = "0.1.0"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "notes-gui"
@@ -436,6 +439,12 @@ dependencies = [
  "notes-core",
  "vte4",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pango"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,3 +12,4 @@ name = "notes"
 path = "src/main.rs"
 
 [dependencies]
+once_cell = "1"

--- a/core/src/graph.rs
+++ b/core/src/graph.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 
-use crate::note::NOTES_DIR;
+use crate::note::vault_dir;
 
 #[derive(Debug)]
 pub struct Graph {
@@ -100,7 +100,7 @@ pub fn build_graph() -> Graph {
     let mut normalized = Vec::new();
     let mut index_map: HashMap<String, usize> = HashMap::new();
 
-    if let Ok(entries) = fs::read_dir(NOTES_DIR) {
+    if let Ok(entries) = fs::read_dir(vault_dir()) {
         for entry in entries.flatten() {
             let path = entry.path();
             if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
@@ -203,7 +203,7 @@ pub fn load_graph_data() -> GraphData {
     let mut normalized = Vec::new();
     let mut contents = Vec::new();
 
-    if let Ok(entries) = fs::read_dir(NOTES_DIR) {
+    if let Ok(entries) = fs::read_dir(vault_dir()) {
         for entry in entries.flatten() {
             let path = entry.path();
             if let (Some(stem), Some(filename)) = (

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -1,9 +1,23 @@
+use once_cell::sync::OnceCell;
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
 // Intentionally removed: use std::path::Path;
 
 pub const NOTES_DIR: &str = "notes";
+
+static VAULT_DIR: OnceCell<PathBuf> = OnceCell::new();
+
+pub fn set_vault_dir<P: Into<PathBuf>>(dir: P) {
+    let _ = VAULT_DIR.set(dir.into());
+}
+
+pub fn vault_dir() -> PathBuf {
+    VAULT_DIR
+        .get()
+        .cloned()
+        .unwrap_or_else(|| PathBuf::from(NOTES_DIR))
+}
 
 #[derive(Debug, Clone)]
 pub struct Note {
@@ -15,7 +29,7 @@ pub struct Note {
 
 impl Note {
     pub fn new(title: String, content: String, aliases: Option<Vec<String>>) -> Self {
-        let mut path = PathBuf::from(NOTES_DIR);
+        let mut path = vault_dir();
         path.push(format!("{}.md", title));
         Note {
             title,
@@ -26,7 +40,7 @@ impl Note {
     }
 
     pub fn save(&self) -> io::Result<()> {
-        fs::create_dir_all(NOTES_DIR)?;
+        fs::create_dir_all(vault_dir())?;
         let mut file = fs::File::create(&self.path)?;
         file.write_all(self.content.as_bytes())?;
         Ok(())
@@ -54,7 +68,7 @@ impl Note {
     }
 
     pub fn path_from_title(title: &str) -> PathBuf {
-        let mut path = PathBuf::from(NOTES_DIR);
+        let mut path = vault_dir();
         path.push(format!("{}.md", title));
         path
     }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -35,31 +35,29 @@ fn show_dashboard(app: &Application) {
         .default_height(200)
         .build();
 
+    let entry = Entry::new();
+    entry.set_hexpand(true);
+    entry.set_placeholder_text(Some("Vault directory"));
     let button = Button::with_label("Open Vault");
-    window.set_child(Some(&button));
+    let vbox = Box::new(Orientation::Vertical, 5);
+    vbox.set_margin_top(12);
+    vbox.set_margin_bottom(12);
+    vbox.set_margin_start(12);
+    vbox.set_margin_end(12);
+    vbox.append(&entry);
+    vbox.append(&button);
+    window.set_child(Some(&vbox));
 
-    button.connect_clicked(glib::clone!(@weak window, @weak app => move |_| {
-        let dialog = gtk4::FileChooserNative::builder()
-            .title("Choose Vault")
-            .action(gtk4::FileChooserAction::SelectFolder)
-            .transient_for(&window)
-            .build();
-        glib::spawn_future_local(glib::clone!(@weak window, @weak app => async move {
-            let response = dialog.run_future().await;
-            if response == gtk4::ResponseType::Accept {
-                if let Some(file) = dialog.file() {
-                    if let Some(path) = file.path() {
-                        set_vault_dir(path);
-                        dialog.destroy();
-                        window.close();
-                        open_main_window(&app);
-                        return;
-                    }
-                }
+    button.connect_clicked(
+        glib::clone!(@weak window, @weak app, @weak entry => move |_| {
+            let path = entry.text();
+            if !path.is_empty() {
+                set_vault_dir(path.as_str());
+                window.close();
+                open_main_window(&app);
             }
-            dialog.destroy();
-        }));
-    }));
+        }),
+    );
     window.show();
 }
 

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -12,11 +12,6 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 pub fn run_gui() {
-    // Fallback to the memory backend if no schemas are installed.
-    if std::env::var("GSETTINGS_BACKEND").is_err() {
-        let _ = glib::setenv("GSETTINGS_BACKEND", "memory", false);
-    }
-
     let app = Application::builder()
         .application_id("com.example.notes")
         .build();
@@ -677,5 +672,14 @@ fn close_current_tab(
 }
 
 fn main() {
+    if std::env::var("GSETTINGS_BACKEND")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .is_none()
+    {
+        unsafe {
+            std::env::set_var("GSETTINGS_BACKEND", "memory");
+        }
+    }
     run_gui();
 }

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -12,6 +12,11 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 pub fn run_gui() {
+    // Fallback to the memory backend if no schemas are installed.
+    if std::env::var("GSETTINGS_BACKEND").is_err() {
+        let _ = glib::setenv("GSETTINGS_BACKEND", "memory", false);
+    }
+
     let app = Application::builder()
         .application_id("com.example.notes")
         .build();


### PR DESCRIPTION
## Summary
- add optional vault directory for notes
- allow setting vault from a startup dashboard
- open files using the selected vault

## Testing
- `cargo build`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_b_685c51edf578833084b99d1da6c7338a